### PR TITLE
Support of Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,16 +88,16 @@ if cython_mode:
 else:
     cython_files = {}
 
-all_cython_files = set(chain(*cython_files.values()))
+all_cython_files = set(chain(*list(cython_files.values())))
 
-print "+++++++++++++++++++"
+print("+++++++++++++++++++")
 
 if cython_mode:
-    print "Cython Files Found: \n%s\n+++++++++++++++++++++" % ", ".join(sorted(all_cython_files))
+    print("Cython Files Found: \n%s\n+++++++++++++++++++++" % ", ".join(sorted(all_cython_files)))
 else:
-    print "Cython support disabled; compiling extensions from pregenerated C sources."
-    print "To enable cython, run setup.py with the option --cython."
-    print "+++++++++++++++++++"
+    print("Cython support disabled; compiling extensions from pregenerated C sources.")
+    print("To enable cython, run setup.py with the option --cython.")
+    print("+++++++++++++++++++")
 
 # Set the compiler arguments -- Add in the environment path stuff
 ld_library_path = os.getenv("LD_LIBRARY_PATH")
@@ -124,7 +124,7 @@ for d, l in chain(((d, glob(join(d, "*.cxx"))) for d in source_directory_list + 
     c_files[d] += l
 
 
-print "C Extension Files Found: \n%s\n+++++++++++++++++++++" % ", ".join(sorted(chain(*c_files.values())))
+print("C Extension Files Found: \n%s\n+++++++++++++++++++++" % ", ".join(sorted(chain(*list(c_files.values())))))
 
 # Collect all the python modules
 def get_python_modules(f):
@@ -137,7 +137,7 @@ python_files -= exclude_files
 
 python_modules = [get_python_modules(f) for f in python_files]
 
-print "Relevant Python Files Found: \n%s\n+++++++++++++++++++++" % ", ".join(sorted(python_files))
+print("Relevant Python Files Found: \n%s\n+++++++++++++++++++++" % ", ".join(sorted(python_files)))
 
 if __name__ == '__main__':
     # The rest is also shared with the setup.py file, in addition to
@@ -196,14 +196,14 @@ if __name__ == '__main__':
         from Cython.Distutils import build_ext
 
         ext_modules += list(chain(*list(makeExtensionList(d, l) 
-                                        for d, l in cython_files.iteritems())))
+                                        for d, l in cython_files.items())))
         
         cmdclass = {'build_ext' : build_ext}
     else:
         cmdclass = {}
 
     ext_modules += list(chain(*list(makeExtensionList(d, l)
-                                    for d, l in c_files.iteritems())))
+                                    for d, l in c_files.items())))
     setup(
         version = version,
         description = description,

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,7 +1,7 @@
 """
 Just a bunch of functions common to the entire test suite
 """
-import random, unittest, cPickle, collections
+import random, unittest, collections
 from treedict import TreeDict, getTree
 import treedict
 from copy import deepcopy, copy
@@ -10,13 +10,13 @@ from hashlib import md5
 import base64, time
 
 
-md5keyhash = md5(str(time.clock()))
+md5keyhash = md5(str(time.clock()).encode('ascii'))
 
 def unique_name():
-    md5keyhash.update(str(time.clock()))
+    md5keyhash.update(str(time.clock()).encode('ascii'))
 
-    return 'u' + (''.join(c for c in base64.b64encode(md5keyhash.digest())
-                          if c.isalnum()))[:6]
+    return 'u' + (''.join(str(c) for c in base64.b64encode(md5keyhash.digest()).decode('ascii')
+                          if str(c).isalnum()))[:6]
 
 def empty_tree():
     return TreeDict(unique_name())
@@ -78,7 +78,7 @@ def frozen_tree():
 def random_node_list(seed, n, dp):
     random.seed(seed)
 
-    idxlist = range(n)
+    idxlist = list(range(n))
     l = [unique_name() for i in idxlist]
     
     while idxlist:

--- a/tests/test_badvalues.py
+++ b/tests/test_badvalues.py
@@ -25,7 +25,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import random, unittest, cPickle, collections
+import random, unittest, collections
 from treedict import TreeDict, getTree
 import treedict
 from copy import deepcopy, copy

--- a/tests/test_branches.py
+++ b/tests/test_branches.py
@@ -26,7 +26,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-import random, unittest, cPickle, collections
+import random, unittest, collections
 from treedict import TreeDict, getTree
 import treedict
 from copy import deepcopy, copy
@@ -377,7 +377,7 @@ class TestAttachPop(unittest.TestCase):
 
         try:
             q = p.aduvulksjucmfiddkjdo.b.pop()
-        except AttributeError, ae:
+        except AttributeError as ae:
             ae_msg = str(ae)
 
         # Make sure it propegates up so the error message is sent from

--- a/tests/test_centralsystem.py
+++ b/tests/test_centralsystem.py
@@ -26,7 +26,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-import random, unittest, cPickle, collections
+import random, unittest, collections
 from treedict import TreeDict, getTree
 import treedict
 from copy import deepcopy, copy

--- a/tests/test_copying.py
+++ b/tests/test_copying.py
@@ -26,7 +26,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-import random, unittest, cPickle, collections
+import random, unittest, collections
 from treedict import TreeDict, getTree
 import treedict
 from copy import deepcopy, copy
@@ -93,7 +93,7 @@ class TestCopying(unittest.TestCase):
 
         try:
             p.aduvulksjucmfiddkjdo.b.copy()
-        except AttributeError, ae:
+        except AttributeError as ae:
             ae_msg = str(ae)
 
         # Make sure it propegates up so the error message is sent from

--- a/tests/test_deletion.py
+++ b/tests/test_deletion.py
@@ -26,7 +26,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-import random, unittest, cPickle, collections
+import random, unittest, collections
 from treedict import TreeDict, getTree
 import treedict
 from copy import deepcopy, copy

--- a/tests/test_dictbehavior.py
+++ b/tests/test_dictbehavior.py
@@ -26,7 +26,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-import random, unittest, cPickle, collections
+import random, unittest, collections
 from treedict import TreeDict, getTree
 import treedict
 from copy import deepcopy, copy

--- a/tests/test_equalities.py
+++ b/tests/test_equalities.py
@@ -26,7 +26,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-import random, unittest, cPickle, collections
+import random, unittest, collections
 from treedict import TreeDict, getTree
 import treedict
 from copy import deepcopy, copy

--- a/tests/test_hashes.py
+++ b/tests/test_hashes.py
@@ -26,7 +26,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-import random, unittest, cPickle, collections
+import random, unittest, collections
 from treedict import TreeDict, getTree, HashError
 import treedict
 from copy import deepcopy, copy
@@ -288,7 +288,7 @@ class TestHashes(unittest.TestCase):
 
         try:
             p.hash()
-        except HashError, he:
+        except HashError as he:
             self.assert_(he.key == 'a.b', he.key)
         
     def testHashError_02(self):
@@ -301,7 +301,7 @@ class TestHashes(unittest.TestCase):
 
         try:
             p.hash()
-        except HashError, he:
+        except HashError as he:
             self.assert_(he.key == 'a.b', he.key)
 
     def testHashError_03(self):
@@ -314,7 +314,7 @@ class TestHashes(unittest.TestCase):
 
         try:
             p.hash()
-        except HashError, he:
+        except HashError as he:
             self.assert_(he.key == 'a.b', he.key)
 
     def testHashError_05_custom(self):

--- a/tests/test_interactivetree.py
+++ b/tests/test_interactivetree.py
@@ -26,7 +26,11 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-import random, unittest, cPickle, collections
+import random, unittest, collections
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 from treedict import TreeDict, getTree
 import treedict
 from copy import deepcopy, copy
@@ -57,8 +61,8 @@ class TestInteractiveTreeDict(unittest.TestCase):
     def testInteractiveTree_04_pickling(self):
         p = sample_tree()
 
-        s = cPickle.dumps(p.interactiveTree(), protocol=0)
-        ipt = cPickle.loads(s)
+        s = pickle.dumps(p.interactiveTree(), protocol=0)
+        ipt = pickle.loads(s)
 
         self.assert_(ipt.treeDict() == p)
         self.assert_(p.interactiveTree() == ipt)

--- a/tests/test_iterators_lists.py
+++ b/tests/test_iterators_lists.py
@@ -27,7 +27,7 @@
 
 from __future__ import division
 
-import random, unittest, cPickle, collections
+import random, unittest, collections
 from treedict import TreeDict, getTree
 import treedict
 from copy import deepcopy, copy
@@ -36,6 +36,9 @@ from hashlib import md5
 import random
 
 from common import *
+
+
+import sys
 
 class TestIteratorsLists(unittest.TestCase):
 
@@ -122,7 +125,7 @@ class TestIteratorsLists(unittest.TestCase):
         for i, k in enumerate(kl):
             p.set(k, i)
 
-        self.assert_(set(p.iterkeys()) == set(kl))
+        self.assertEqual(set(p.iterkeys()), set(kl))
         self.assert_(set(p.itervalues()) == set(range(n)))
 
     def _checkAllIterators(self, p, test, rid):
@@ -785,7 +788,7 @@ class TestIteratorsLists(unittest.TestCase):
         it = p.iterkeys()
         
         self.assertRaises(RuntimeError, lambda: p.pop('a'))
-        it.next()
+        it.__next__()
         self.assertRaises(RuntimeError, lambda: p.pop('a'))
         
         del it
@@ -825,7 +828,7 @@ class TestIteratorsLists(unittest.TestCase):
             else:
                 return p.iteritems(recursive, branch_mode)
 
-        iter_list = [newIter() for i in xrange(n_iter)]
+        iter_list = [newIter() for i in range(n_iter)]
 
         while len(iter_list) > 0:
 
@@ -833,7 +836,7 @@ class TestIteratorsLists(unittest.TestCase):
 
             for i, it in enumerate(iter_list):
                 try:
-                    it.next()
+                    it.__next__()
                 except StopIteration:
                     self.assert_(p._iteratorRefCount() <= len(iter_list))
                     del_queue.append(i)

--- a/tests/test_matching.py
+++ b/tests/test_matching.py
@@ -26,7 +26,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-import random, unittest, cPickle, collections
+import random, unittest, collections
 from treedict import TreeDict, getTree
 import treedict
 from copy import deepcopy, copy

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -26,7 +26,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-import random, unittest, cPickle, collections
+import random, unittest, collections
 from treedict import TreeDict, getTree
 import treedict
 from copy import deepcopy, copy

--- a/tests/test_pickling.py
+++ b/tests/test_pickling.py
@@ -26,7 +26,11 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-import random, unittest, cPickle, collections
+import random, unittest, collections
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
 from treedict import TreeDict, getTree
 import treedict
 from copy import deepcopy, copy
@@ -40,43 +44,43 @@ class TestPickling(unittest.TestCase):
        
     def testPickling_P0(self):
         p = sample_tree()
-        s = cPickle.dumps(p, protocol=0)
-        p2 = cPickle.loads(s)
+        s = pickle.dumps(p, protocol=0)
+        p2 = pickle.loads(s)
 
         self.assert_(p == p2)
 
     def testPickling_P1(self):
         p = sample_tree()
-        s = cPickle.dumps(p, protocol=1)
-        p2 = cPickle.loads(s)
+        s = pickle.dumps(p, protocol=1)
+        p2 = pickle.loads(s)
         
         self.assert_(p == p2)
 
     def testPickling_P2(self):
         p = sample_tree()
-        s = cPickle.dumps(p, protocol=2)
-        p2 = cPickle.loads(s)
+        s = pickle.dumps(p, protocol=2)
+        p2 = pickle.loads(s)
         
         self.assert_(p == p2)
 
     def testPickling_P0f(self):
         p = frozen_tree()
-        s = cPickle.dumps(p, protocol=0)
-        p2 = cPickle.loads(s)
+        s = pickle.dumps(p, protocol=0)
+        p2 = pickle.loads(s)
 
         self.assert_(p == p2)
 
     def testPickling_P1f(self):
         p = frozen_tree()
-        s = cPickle.dumps(p, protocol=1)
-        p2 = cPickle.loads(s)
+        s = pickle.dumps(p, protocol=1)
+        p2 = pickle.loads(s)
         
         self.assert_(p == p2)
 
     def testPickling_P2f(self):
         p = frozen_tree()
-        s = cPickle.dumps(p, protocol=2)
-        p2 = cPickle.loads(s)
+        s = pickle.dumps(p, protocol=2)
+        p2 = pickle.loads(s)
         
         self.assert_(p2.isFrozen())
         self.assert_(p == p2)
@@ -86,7 +90,7 @@ class TestPickling(unittest.TestCase):
         p = TreeDict()
         p.a
 
-        p2 = cPickle.loads(cPickle.dumps(p, protocol=2))
+        p2 = pickle.loads(pickle.dumps(p, protocol=2))
 
         self.assert_(p2 == p)
 
@@ -95,7 +99,7 @@ class TestPickling(unittest.TestCase):
         p = TreeDict()
         p.a = p.b
 
-        p2 = cPickle.loads(cPickle.dumps(p, protocol=2))
+        p2 = pickle.loads(pickle.dumps(p, protocol=2))
 
         self.assert_(p2 == p)
 
@@ -106,7 +110,7 @@ class TestPickling(unittest.TestCase):
         
         p.b = 2
 
-        p2 = cPickle.loads(cPickle.dumps(p, protocol=2))
+        p2 = pickle.loads(pickle.dumps(p, protocol=2))
 
         self.assert_(p2 == p)
 
@@ -120,7 +124,7 @@ class TestPickling(unittest.TestCase):
 
         it = p.iteritems()
 
-        p2 = cPickle.loads(cPickle.dumps(p, protocol=2))
+        p2 = pickle.loads(pickle.dumps(p, protocol=2))
 
         self.assert_(p == p2)
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -26,7 +26,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-import random, unittest, cPickle, collections
+import random, unittest, collections
 from treedict import TreeDict, getTree
 import treedict
 from copy import deepcopy, copy
@@ -278,7 +278,7 @@ class TestProperties(unittest.TestCase):
 
         n_root_leaves = len([k for k in kl if '.' not in k])
 
-        self.assert_(len(p) == n)
+        self.assertEqual(len(p), n)
         self.assert_(p.size() == n)
         self.assert_(p.size(recursive = False) == n_root_leaves)
         self.assert_(p.size(recursive = False, branch_mode = "all") == n)

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -25,7 +25,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import random, unittest, cPickle, collections
+import random, unittest, collections
 from treedict import TreeDict, getTree
 import treedict
 from copy import deepcopy, copy

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -26,7 +26,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-import random, unittest, cPickle, collections
+import random, unittest, collections
 from treedict import TreeDict, getTree
 import treedict
 from copy import deepcopy, copy

--- a/tests/test_setting.py
+++ b/tests/test_setting.py
@@ -26,7 +26,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-import random, unittest, cPickle, collections
+import random, unittest, collections
 from treedict import TreeDict, getTree
 import treedict
 from copy import deepcopy, copy

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -26,7 +26,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-import random, unittest, cPickle, collections
+import random, unittest, collections
 from treedict import TreeDict, getTree
 import treedict
 from copy import deepcopy, copy

--- a/treedict/__init__.py
+++ b/treedict/__init__.py
@@ -1,2 +1,2 @@
-from treedict import TreeDict, getTree, treeExists, HashError
+from .treedict import TreeDict, getTree, treeExists, HashError
 

--- a/treedict/name_matching.pxd
+++ b/treedict/name_matching.pxd
@@ -33,12 +33,14 @@
 # want to weight the results so that starting overlaps are weighted
 # closer.
 
+import sys
+
+#cdef bint IS_PYTHON2 = sys.version_info[0] <= 2
 
 from minsmaxes cimport min3
 from membuffers cimport size_t_v, resize_size_t_v
 import warnings
 from minsmaxes cimport min2_long
-
 
 cdef inline long _combine_scores(long n_beginning, long n_groups, long n_end_groups, long n1, long n2, long ldist):
     # make sure that beginning matching is most important
@@ -57,8 +59,10 @@ cdef inline long name_match_distance(size_t_v *calc_buffer,
     if n1 == 0: return n2
     if n2 == 0: return n1
 
-    cdef char* s = <bytes>s1
-    cdef char* t = <bytes>s2
+    s_s1 = s1.encode('utf-8')
+    t_s2 = s2.encode('utf-8')
+    cdef char* s = s_s1
+    cdef char* t = t_s2
     
     cdef size_t n_beginning = 0, n_groups = 0, n_end_groups = 0
 
@@ -103,8 +107,11 @@ cdef inline long editDistance(size_t_v *calc_buffer, str s1, str s2):
     if s1 == s2: 
         return 0
 
-    cdef char* s = <bytes>s1
-    cdef char* t = <bytes>s2
+    s_s1 = s1.encode('utf-8')
+    t_s2 = s2.encode('utf-8')
+    cdef char* s = s_s1
+    cdef char* t = t_s2
+
     
     # Get the overlap at the beginning; this is important
     while s[0] == t[0]:


### PR DESCRIPTION
Hi,

Thanks for your wonderful package, I use it for running sets of simulations on clusters. I needed Python 3 support, so I implemented it.

The code has been tested on 2.7.3, 3.2.4 and 3.3.1 (all unit tests pass), on OS X. It is far from elegant or optimal, and it may adversely affect performance. The main changes are : 
1. print statements
2. the str/bytes conundrum, of importance for hashes.
3. the iteritems/items for dict.
4. the cPickle package.

Optimization may be possible.
