### PR TITLE
fixes for python3

### DIFF
--- a/treedict/treedict.pyx
+++ b/treedict/treedict.pyx
@@ -264,7 +264,7 @@ cdef _runValueHash(hf, value):
         hf("$$$DICT".encode('utf-8'))
         value_items = (sorted(<dict>value.iteritems())
                        if IS_PYTHON2
-                       else list(sorted(<dict>value).items()))
+                       else sorted(<dict>value.items()))
         
         for k, v in <list>(value_items):
             _runValueHash(hf, k)
@@ -1740,7 +1740,8 @@ cdef class TreeDict(object):
                 self._n_mutable = 0
                 self._next_item_order_position = _orderNodeStartingValue
             else:
-                for k, pn in self._param_dict.items():
+                _param_dict_listitems = self._param_dict.items() if IS_PYTHON2 else list(self._param_dict.items())
+                for k, pn in _param_dict_listitems:
                     if b_mode == i_BranchMode_Only:
                         if pn.isBranch():
                             self._cut(k, pn)
@@ -3772,7 +3773,7 @@ cdef class TreeDict(object):
 
             self._setHasBeenCopiedFlag(False)
 
-            for pnv in self._param_dict.values():
+            for pnv in self._param_dict.values() if IS_PYTHON2 else list(self._param_dict.values()):
                 pn = <_PTreeNode>pnv
 
                 if pn.isTree():


### PR DESCRIPTION
Hello hoytak,

Pulled your changes, the test were running fine on 2.7.3, but producing errors in 3.3.1. I fixed them, undoing some of your optimizations, I am afraid.
As for my name it is Fabien Benureau, and you can reference the site of my lab : flowers.inria.fr. 

Best,
Fabien

```
python tests.py
...................................EE.................................................................................................................................................E..................E..........................................................................................................................................................................................................................................................................................................................................................................................................................................
======================================================================
ERROR: testClear_02_branches_only (test_branches.TestAttachPop)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/fabien/Research/local/treedict/tests/test_branches.py", line 454, in testClear_02_branches_only
    p.clear("only")
  File "treedict.pyx", line 1752, in treedict.treedict.TreeDict.clear (treedict/treedict.c:15920)
  File "treedict.pyx", line 1743, in treedict.treedict.TreeDict.clear (treedict/treedict.c:15717)
RuntimeError: dictionary changed size during iteration

======================================================================
ERROR: testClear_03_branches_none (test_branches.TestAttachPop)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/fabien/Research/local/treedict/tests/test_branches.py", line 466, in testClear_03_branches_none
    p.clear("none")
  File "treedict.pyx", line 1752, in treedict.treedict.TreeDict.clear (treedict/treedict.c:15920)
  File "treedict.pyx", line 1743, in treedict.treedict.TreeDict.clear (treedict/treedict.c:15717)
RuntimeError: dictionary changed size during iteration

======================================================================
ERROR: testHashError_03 (test_hashes.TestHashes)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/fabien/Research/local/treedict/tests/test_hashes.py", line 313, in testHashError_03
    self.assertRaises(HashError, lambda: p.hash())
  File "/Users/fabien/.pythonbrew/pythons/Python-3.3.1/lib/python3.3/unittest/case.py", line 571, in assertRaises
    return context.handle('assertRaises', callableObj, args, kwargs)
  File "/Users/fabien/.pythonbrew/pythons/Python-3.3.1/lib/python3.3/unittest/case.py", line 135, in handle
    callable_obj(*args, **kwargs)
  File "/Users/fabien/Research/local/treedict/tests/test_hashes.py", line 313, in <lambda>
    self.assertRaises(HashError, lambda: p.hash())
  File "treedict.pyx", line 3204, in treedict.treedict.TreeDict.hash (treedict/treedict.c:29375)
  File "treedict.pyx", line 3283, in treedict.treedict.TreeDict.hash (treedict/treedict.c:29231)
  File "treedict.pyx", line 3280, in treedict.treedict.TreeDict.hash (treedict/treedict.c:29163)
  File "treedict.pyx", line 3330, in treedict.treedict.TreeDict._self_hash (treedict/treedict.c:30005)
  File "treedict.pyx", line 3375, in treedict.treedict.TreeDict._runFullHash (treedict/treedict.c:30450)
  File "treedict.pyx", line 511, in treedict.treedict._PTreeNode.runFullHash (treedict/treedict.c:5496)
  File "treedict.pyx", line 3375, in treedict.treedict.TreeDict._runFullHash (treedict/treedict.c:30450)
  File "treedict.pyx", line 515, in treedict.treedict._PTreeNode.runFullHash (treedict/treedict.c:5554)
  File "treedict.pyx", line 267, in treedict.treedict._runValueHash (treedict/treedict.c:3619)
AttributeError: 'list' object has no attribute 'items'
```
